### PR TITLE
Added OpenCV >3.0 required to CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif(COMMAND cmake_policy)
 
 # ============================================================================ #
 # OpenCV
-find_package(OpenCV REQUIRED)
+find_package(OpenCV 3.0 REQUIRED)
 message("-- OPENCV include:   " ${OpenCV_INCLUDE_DIRS})
 
 include_directories(


### PR DESCRIPTION
I have a 3.x installation at /usr/local/include and a 2.x installation at /usr/include. Using netbeans with cmake to generate project was automatically picking up the 2.x version and wasn't compiling. Generating and compiling in console was picking up the 3.x version.